### PR TITLE
BuildContext's across async gaps warning 

### DIFF
--- a/lib/feature/context_async/api_service.dart
+++ b/lib/feature/context_async/api_service.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class ApiClass {
+  Future<void> getData(BuildContext context) async {
+    final result = await Future<bool>.delayed(
+      const Duration(seconds: 3),
+      () {
+        return true;
+      },
+    );
+    if (result) {
+      // How we refactor  this code to avoid BuildContext's across async gaps
+      showCustomDialog(context);
+    }
+  }
+
+  void showCustomDialog(BuildContext context) {
+    showAdaptiveDialog<bool>(
+      context: context,
+      builder: (context) => const Text('Your result is successful'),
+    );
+  }
+}


### PR DESCRIPTION
Hello Mr. Veli 
I want to call an API without using widgets, if the result is successful it should show an alert or a bottomsheet, I send the context with function parameters, this code works normally only giving context async gaps warning. 
How we can do refactoring of this code 
Thank you!